### PR TITLE
various speed improvements

### DIFF
--- a/BohleBots_BNO055.cpp
+++ b/BohleBots_BNO055.cpp
@@ -31,8 +31,6 @@ BNO::BNO()
 
 int16_t BNO::getHeading()	//reads the lSB and MSB of the EUL_HEADING and outputs the combined value
 {
-	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
-
 	int16_t heading = 0;
 	heading = readRegister16(BNO_ADDR, EUL_HEADING_LSB_ADDR);
 	return (heading/16)+1;
@@ -40,7 +38,6 @@ int16_t BNO::getHeading()	//reads the lSB and MSB of the EUL_HEADING and outputs
 
 bool BNO::getImpact()	//reads the INT_STA Register to check if a High_G event occurred
 {
-	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
 	return (readRegister(BNO_ADDR, INT_STA_ADDR)&B00100000)>>5;
 }
 
@@ -149,8 +146,6 @@ void BNO::writeRegister(uint8_t addr, uint8_t regaddr, uint8_t value)	//writes b
 
 void BNO::getOffsets(struct calibOffsets *ptr)
 {
-	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
-  
 	ptr->acc_x = readRegister(BNO_ADDR, ACC_OFFSET_X_MSB_ADDR)<<8;
 	ptr->acc_x += readRegister(BNO_ADDR, ACC_OFFSET_X_LSB_ADDR);
 	ptr->acc_y = readRegister(BNO_ADDR, ACC_OFFSET_Y_MSB_ADDR)<<8;
@@ -181,8 +176,6 @@ void BNO::getOffsets(struct calibOffsets *ptr)
 
 void BNO::setOffsets(struct calibOffsets *ptr)	//writes given offset structure into the compass
 {
-	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
-
 	writeRegister(BNO_ADDR, OPR_MODE_ADDR, OPR_MODE_CONFIG);
 	delay(19);
 
@@ -218,8 +211,6 @@ void BNO::setOffsets(struct calibOffsets *ptr)	//writes given offset structure i
 
 void BNO::getCalibStat(struct calibStat *ptr)	//gets current calibration status
 {
-	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
-
 	ptr->sys = (readRegister(BNO_ADDR, CALIB_STAT_ADDR)&B11000000)>>6;
 	ptr->gyr = (readRegister(BNO_ADDR, CALIB_STAT_ADDR)&B00110000)>>4;
 	ptr->acc = (readRegister(BNO_ADDR, CALIB_STAT_ADDR)&B00001100)>>2;

--- a/BohleBots_BNO055.cpp
+++ b/BohleBots_BNO055.cpp
@@ -238,8 +238,9 @@ void BNO::setOffsets(struct calibOffsets *ptr)	//writes given offset structure i
 
 void BNO::getCalibStat(struct calibStat *ptr)	//gets current calibration status
 {
-	ptr->sys = (readRegister(CALIB_STAT_ADDR)&B11000000)>>6;
-	ptr->gyr = (readRegister(CALIB_STAT_ADDR)&B00110000)>>4;
-	ptr->acc = (readRegister(CALIB_STAT_ADDR)&B00001100)>>2;
-	ptr->mag = readRegister(CALIB_STAT_ADDR)&B00000011;
+	uint8_t tmp = readRegister(CALIB_STAT_ADDR);
+	ptr->sys = (tmp&B11000000)>>6;
+	ptr->gyr = (tmp&B00110000)>>4;
+	ptr->acc = (tmp&B00001100)>>2;
+	ptr->mag = tmp&B00000011;
 }

--- a/BohleBots_BNO055.cpp
+++ b/BohleBots_BNO055.cpp
@@ -34,8 +34,7 @@ int16_t BNO::getHeading()	//reads the lSB and MSB of the EUL_HEADING and outputs
 	if(readRegister(BNO_ADDR, PAGE_ID_ADDR) != 0) writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
 
 	int16_t heading = 0;
-	heading = readRegister(BNO_ADDR, EUL_HEADING_MSB_ADDR)<<8;
-	heading += readRegister(BNO_ADDR, EUL_HEADING_LSB_ADDR);
+	heading = readRegister16(BNO_ADDR, EUL_HEADING_LSB_ADDR);
 	return (heading/16)+1;
 }
 
@@ -122,10 +121,21 @@ uint8_t BNO::readRegister(uint8_t addr, uint8_t regaddr)	//reads byte from a reg
 	uint8_t value = 0;
 	writePhase(addr, regaddr);
 	Wire.requestFrom((int)addr,1,true);
-	while(Wire.available())
-	{
-		value = Wire.read();
-	}
+	while(Wire.available() < 1);
+	value = Wire.read();
+	return value;
+}
+
+uint16_t BNO::readRegister16(uint8_t addr, uint8_t regaddr)
+{
+	uint16_t value = 0;
+	uint8_t tmp = 0;
+	writePhase(addr, regaddr);
+	Wire.requestFrom((int)addr,2,true);
+	while(Wire.available() < 2);
+	tmp = Wire.read();
+	value = Wire.read()<<8;
+	value += tmp;
 	return value;
 }
 

--- a/BohleBots_BNO055.cpp
+++ b/BohleBots_BNO055.cpp
@@ -31,7 +31,7 @@ BNO::BNO()
 
 int16_t BNO::getHeading()	//reads the lSB and MSB of the EUL_HEADING and outputs the combined value
 {
-	if(readRegister(BNO_ADDR, PAGE_ID_ADDR) != 0) writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
+	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
 
 	int16_t heading = 0;
 	heading = readRegister16(BNO_ADDR, EUL_HEADING_LSB_ADDR);
@@ -40,7 +40,7 @@ int16_t BNO::getHeading()	//reads the lSB and MSB of the EUL_HEADING and outputs
 
 bool BNO::getImpact()	//reads the INT_STA Register to check if a High_G event occurred
 {
-	if(readRegister(BNO_ADDR, PAGE_ID_ADDR) != 0) writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
+	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
 	return (readRegister(BNO_ADDR, INT_STA_ADDR)&B00100000)>>5;
 }
 
@@ -75,10 +75,10 @@ void BNO::loadOffsets(unsigned int address)	//loads offsets structure from eepro
 void BNO::startBNO(uint8_t impact, bool forward)	//enables High_g Interrupt and puts the Compass into NDOF fusion mode
 {
 	//Enable High-G Interrupt
-	if(readRegister(BNO_ADDR, PAGE_ID_ADDR) != 0) writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
+	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
 	writeRegister(BNO_ADDR, OPR_MODE_ADDR, OPR_MODE_CONFIG);
 	delay(19);
-	if(readRegister(BNO_ADDR, PAGE_ID_ADDR) != 1) writeRegister(BNO_ADDR, PAGE_ID_ADDR, 1);
+	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 1);
 
 	writeRegister(BNO_ADDR, INT_EN_ADDR, B00100000);
 	writeRegister(BNO_ADDR, INT_MSK_ADDR, B00000000);
@@ -94,7 +94,7 @@ void BNO::startBNO(uint8_t impact, bool forward)	//enables High_g Interrupt and 
 	}
 
 	//Change Operation mode
-	if(readRegister(BNO_ADDR, PAGE_ID_ADDR) != 0) writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
+	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
 
 	writeRegister(BNO_ADDR, OPR_MODE_ADDR, OPR_MODE_NDOF);
 	delay(19);
@@ -149,7 +149,7 @@ void BNO::writeRegister(uint8_t addr, uint8_t regaddr, uint8_t value)	//writes b
 
 void BNO::getOffsets(struct calibOffsets *ptr)
 {
-	if(readRegister(BNO_ADDR, PAGE_ID_ADDR) != 0) writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
+	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
   
 	ptr->acc_x = readRegister(BNO_ADDR, ACC_OFFSET_X_MSB_ADDR)<<8;
 	ptr->acc_x += readRegister(BNO_ADDR, ACC_OFFSET_X_LSB_ADDR);
@@ -181,7 +181,7 @@ void BNO::getOffsets(struct calibOffsets *ptr)
 
 void BNO::setOffsets(struct calibOffsets *ptr)	//writes given offset structure into the compass
 {
-	if(readRegister(BNO_ADDR, PAGE_ID_ADDR) != 0) writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
+	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
 
 	writeRegister(BNO_ADDR, OPR_MODE_ADDR, OPR_MODE_CONFIG);
 	delay(19);
@@ -218,7 +218,7 @@ void BNO::setOffsets(struct calibOffsets *ptr)	//writes given offset structure i
 
 void BNO::getCalibStat(struct calibStat *ptr)	//gets current calibration status
 {
-	if(readRegister(BNO_ADDR, PAGE_ID_ADDR) != 0) writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
+	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
 
 	ptr->sys = (readRegister(BNO_ADDR, CALIB_STAT_ADDR)&B11000000)>>6;
 	ptr->gyr = (readRegister(BNO_ADDR, CALIB_STAT_ADDR)&B00110000)>>4;

--- a/BohleBots_BNO055.cpp
+++ b/BohleBots_BNO055.cpp
@@ -32,13 +32,13 @@ BNO::BNO()
 int16_t BNO::getHeading()	//reads the lSB and MSB of the EUL_HEADING and outputs the combined value
 {
 	int16_t heading = 0;
-	heading = readRegister16(BNO_ADDR, EUL_HEADING_LSB_ADDR);
+	heading = readRegister16(EUL_HEADING_LSB_ADDR);
 	return (heading/16)+1;
 }
 
 bool BNO::getImpact()	//reads the INT_STA Register to check if a High_G event occurred
 {
-	return (readRegister(BNO_ADDR, INT_STA_ADDR)&B00100000)>>5;
+	return (readRegister(INT_STA_ADDR)&B00100000)>>5;
 }
 
 bool BNO::isCalibrated()	//Gets the latest calibration values and does a bitwise and to return a true if everything is fully calibrated
@@ -72,31 +72,31 @@ void BNO::loadOffsets(unsigned int address)	//loads offsets structure from eepro
 void BNO::startBNO(uint8_t impact, bool forward)	//enables High_g Interrupt and puts the Compass into NDOF fusion mode
 {
 	//Enable High-G Interrupt
-	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
-	writeRegister(BNO_ADDR, OPR_MODE_ADDR, OPR_MODE_CONFIG);
+	writeRegister(PAGE_ID_ADDR, 0);
+	writeRegister(OPR_MODE_ADDR, OPR_MODE_CONFIG);
 	delay(19);
-	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 1);
+	writeRegister(PAGE_ID_ADDR, 1);
 
-	writeRegister(BNO_ADDR, INT_EN_ADDR, B00100000);
-	writeRegister(BNO_ADDR, INT_MSK_ADDR, B00000000);
-	writeRegister(BNO_ADDR, ACC_INT_Settings_ADDR, B01100000);
-	writeRegister(BNO_ADDR, ACC_HG_DURATION_ADDR, 1);
-	writeRegister(BNO_ADDR, ACC_HG_THRES_ADDR, impact);
+	writeRegister(INT_EN_ADDR, B00100000);
+	writeRegister(INT_MSK_ADDR, B00000000);
+	writeRegister(ACC_INT_Settings_ADDR, B01100000);
+	writeRegister(ACC_HG_DURATION_ADDR, 1);
+	writeRegister(ACC_HG_THRES_ADDR, impact);
 	if(forward)
 	{
-	       	writeRegister(BNO_ADDR, INT_MSK_ADDR, B00100000);
+	       	writeRegister(INT_MSK_ADDR, B00100000);
 	}else
 	{
-		writeRegister(BNO_ADDR, INT_MSK_ADDR, B00000000);
+		writeRegister(INT_MSK_ADDR, B00000000);
 	}
 
 	//Change Operation mode
-	writeRegister(BNO_ADDR, PAGE_ID_ADDR, 0);
+	writeRegister(PAGE_ID_ADDR, 0);
 
-	writeRegister(BNO_ADDR, OPR_MODE_ADDR, OPR_MODE_NDOF);
+	writeRegister(OPR_MODE_ADDR, OPR_MODE_NDOF);
 	delay(19);
 
-	uint8_t sysStatus = readRegister(BNO_ADDR, SYS_STATUS_ADDR);
+	uint8_t sysStatus = readRegister(SYS_STATUS_ADDR);
 	if(sysStatus != 5)
 	{
 		Serial.print("SYS_STATUS:\t");  Serial.println(sysStatus, DEC);
@@ -106,29 +106,29 @@ void BNO::startBNO(uint8_t impact, bool forward)	//enables High_g Interrupt and 
 
 /***** Private Functions *****/
 
-void BNO::writePhase(uint8_t addr, uint8_t regaddr)	//Write Phase needed to tell from which address we want to read
+void BNO::writePhase(uint8_t regaddr)	//Write Phase needed to tell from which address we want to read
 {
-	Wire.beginTransmission(addr);
+	Wire.beginTransmission(BNO_ADDR);
 	Wire.write(regaddr);
 	Wire.endTransmission();
 }
 
-uint8_t BNO::readRegister(uint8_t addr, uint8_t regaddr)	//reads byte from a register
+uint8_t BNO::readRegister(uint8_t regaddr)	//reads byte from a register
 {
 	uint8_t value = 0;
-	writePhase(addr, regaddr);
-	Wire.requestFrom((int)addr,1,true);
+	writePhase(regaddr);
+	Wire.requestFrom(BNO_ADDR,1,true);
 	while(Wire.available() < 1);
 	value = Wire.read();
 	return value;
 }
 
-uint16_t BNO::readRegister16(uint8_t addr, uint8_t regaddr)
+uint16_t BNO::readRegister16(uint8_t regaddr)
 {
 	uint16_t value = 0;
 	uint8_t tmp = 0;
-	writePhase(addr, regaddr);
-	Wire.requestFrom((int)addr,2,true);
+	writePhase(regaddr);
+	Wire.requestFrom(BNO_ADDR,2,true);
 	while(Wire.available() < 2);
 	tmp = Wire.read();
 	value = Wire.read()<<8;
@@ -136,9 +136,9 @@ uint16_t BNO::readRegister16(uint8_t addr, uint8_t regaddr)
 	return value;
 }
 
-void BNO::writeRegister(uint8_t addr, uint8_t regaddr, uint8_t value)	//writes byte to a register
+void BNO::writeRegister(uint8_t regaddr, uint8_t value)	//writes byte to a register
 {
-	Wire.beginTransmission(addr);
+	Wire.beginTransmission(BNO_ADDR);
 	Wire.write(regaddr);
 	Wire.write(value);
 	Wire.endTransmission();
@@ -147,7 +147,7 @@ void BNO::writeRegister(uint8_t addr, uint8_t regaddr, uint8_t value)	//writes b
 void BNO::getOffsets(struct calibOffsets *ptr)
 {
 	uint8_t tmp = 0;
-	writePhase(BNO_ADDR, ACC_OFFSET_X_LSB_ADDR);
+	writePhase(ACC_OFFSET_X_LSB_ADDR);
 	Wire.requestFrom(BNO_ADDR, 22, true);
 	while(Wire.available() < 22);
 
@@ -203,43 +203,43 @@ void BNO::getOffsets(struct calibOffsets *ptr)
 
 void BNO::setOffsets(struct calibOffsets *ptr)	//writes given offset structure into the compass
 {
-	writeRegister(BNO_ADDR, OPR_MODE_ADDR, OPR_MODE_CONFIG);
+	writeRegister(OPR_MODE_ADDR, OPR_MODE_CONFIG);
 	delay(19);
 
-	writeRegister(BNO_ADDR, ACC_OFFSET_X_MSB_ADDR, (ptr->acc_x)>>8);
-	writeRegister(BNO_ADDR, ACC_OFFSET_X_LSB_ADDR, (ptr->acc_x)&B11111111);
-	writeRegister(BNO_ADDR, ACC_OFFSET_Y_MSB_ADDR, (ptr->acc_y)>>8);
-	writeRegister(BNO_ADDR, ACC_OFFSET_Y_LSB_ADDR, (ptr->acc_y)&B11111111);
-	writeRegister(BNO_ADDR, ACC_OFFSET_Z_MSB_ADDR, (ptr->acc_z)>>8);
-	writeRegister(BNO_ADDR, ACC_OFFSET_Z_LSB_ADDR, (ptr->acc_z)&B11111111);
+	writeRegister(ACC_OFFSET_X_MSB_ADDR, (ptr->acc_x)>>8);
+	writeRegister(ACC_OFFSET_X_LSB_ADDR, (ptr->acc_x)&B11111111);
+	writeRegister(ACC_OFFSET_Y_MSB_ADDR, (ptr->acc_y)>>8);
+	writeRegister(ACC_OFFSET_Y_LSB_ADDR, (ptr->acc_y)&B11111111);
+	writeRegister(ACC_OFFSET_Z_MSB_ADDR, (ptr->acc_z)>>8);
+	writeRegister(ACC_OFFSET_Z_LSB_ADDR, (ptr->acc_z)&B11111111);
 
-	writeRegister(BNO_ADDR, MAG_OFFSET_X_MSB_ADDR, (ptr->mag_x)>>8);
-	writeRegister(BNO_ADDR, MAG_OFFSET_X_LSB_ADDR, (ptr->mag_x)&B11111111);
-	writeRegister(BNO_ADDR, MAG_OFFSET_Y_MSB_ADDR, (ptr->mag_y)>>8);
-	writeRegister(BNO_ADDR, MAG_OFFSET_Y_LSB_ADDR, (ptr->mag_y)&B11111111);
-	writeRegister(BNO_ADDR, MAG_OFFSET_Z_MSB_ADDR, (ptr->mag_z)>>8);
-	writeRegister(BNO_ADDR, MAG_OFFSET_Z_LSB_ADDR, (ptr->mag_z)&B11111111);
+	writeRegister(MAG_OFFSET_X_MSB_ADDR, (ptr->mag_x)>>8);
+	writeRegister(MAG_OFFSET_X_LSB_ADDR, (ptr->mag_x)&B11111111);
+	writeRegister(MAG_OFFSET_Y_MSB_ADDR, (ptr->mag_y)>>8);
+	writeRegister(MAG_OFFSET_Y_LSB_ADDR, (ptr->mag_y)&B11111111);
+	writeRegister(MAG_OFFSET_Z_MSB_ADDR, (ptr->mag_z)>>8);
+	writeRegister(MAG_OFFSET_Z_LSB_ADDR, (ptr->mag_z)&B11111111);
 
-	writeRegister(BNO_ADDR, GYR_OFFSET_X_MSB_ADDR, (ptr->gyr_x)>>8);
-	writeRegister(BNO_ADDR, GYR_OFFSET_X_LSB_ADDR, (ptr->gyr_x)&B11111111);
-	writeRegister(BNO_ADDR, GYR_OFFSET_Y_MSB_ADDR, (ptr->gyr_y)>>8);
-	writeRegister(BNO_ADDR, GYR_OFFSET_Y_LSB_ADDR, (ptr->gyr_y)&B11111111);
-	writeRegister(BNO_ADDR, GYR_OFFSET_Z_MSB_ADDR, (ptr->gyr_z)>>8);
-	writeRegister(BNO_ADDR, GYR_OFFSET_Z_LSB_ADDR, (ptr->gyr_z)&B11111111);
+	writeRegister(GYR_OFFSET_X_MSB_ADDR, (ptr->gyr_x)>>8);
+	writeRegister(GYR_OFFSET_X_LSB_ADDR, (ptr->gyr_x)&B11111111);
+	writeRegister(GYR_OFFSET_Y_MSB_ADDR, (ptr->gyr_y)>>8);
+	writeRegister(GYR_OFFSET_Y_LSB_ADDR, (ptr->gyr_y)&B11111111);
+	writeRegister(GYR_OFFSET_Z_MSB_ADDR, (ptr->gyr_z)>>8);
+	writeRegister(GYR_OFFSET_Z_LSB_ADDR, (ptr->gyr_z)&B11111111);
 
-	writeRegister(BNO_ADDR, ACC_RADIUS_MSB_ADDR, (ptr->acc_rad)>>8);
-	writeRegister(BNO_ADDR, ACC_RADIUS_LSB_ADDR, (ptr->acc_rad)&B11111111);
-	writeRegister(BNO_ADDR, MAG_RADIUS_MSB_ADDR, (ptr->mag_rad)>>8);
-	writeRegister(BNO_ADDR, MAG_RADIUS_LSB_ADDR, (ptr->mag_rad)&B11111111);
+	writeRegister(ACC_RADIUS_MSB_ADDR, (ptr->acc_rad)>>8);
+	writeRegister(ACC_RADIUS_LSB_ADDR, (ptr->acc_rad)&B11111111);
+	writeRegister(MAG_RADIUS_MSB_ADDR, (ptr->mag_rad)>>8);
+	writeRegister(MAG_RADIUS_LSB_ADDR, (ptr->mag_rad)&B11111111);
 
-	writeRegister(BNO_ADDR, OPR_MODE_ADDR, OPR_MODE_NDOF);
+	writeRegister(OPR_MODE_ADDR, OPR_MODE_NDOF);
 	delay(19);
 }
 
 void BNO::getCalibStat(struct calibStat *ptr)	//gets current calibration status
 {
-	ptr->sys = (readRegister(BNO_ADDR, CALIB_STAT_ADDR)&B11000000)>>6;
-	ptr->gyr = (readRegister(BNO_ADDR, CALIB_STAT_ADDR)&B00110000)>>4;
-	ptr->acc = (readRegister(BNO_ADDR, CALIB_STAT_ADDR)&B00001100)>>2;
-	ptr->mag = readRegister(BNO_ADDR, CALIB_STAT_ADDR)&B00000011;
+	ptr->sys = (readRegister(CALIB_STAT_ADDR)&B11000000)>>6;
+	ptr->gyr = (readRegister(CALIB_STAT_ADDR)&B00110000)>>4;
+	ptr->acc = (readRegister(CALIB_STAT_ADDR)&B00001100)>>2;
+	ptr->mag = readRegister(CALIB_STAT_ADDR)&B00000011;
 }

--- a/BohleBots_BNO055.cpp
+++ b/BohleBots_BNO055.cpp
@@ -146,32 +146,59 @@ void BNO::writeRegister(uint8_t addr, uint8_t regaddr, uint8_t value)	//writes b
 
 void BNO::getOffsets(struct calibOffsets *ptr)
 {
-	ptr->acc_x = readRegister(BNO_ADDR, ACC_OFFSET_X_MSB_ADDR)<<8;
-	ptr->acc_x += readRegister(BNO_ADDR, ACC_OFFSET_X_LSB_ADDR);
-	ptr->acc_y = readRegister(BNO_ADDR, ACC_OFFSET_Y_MSB_ADDR)<<8;
-	ptr->acc_y += readRegister(BNO_ADDR, ACC_OFFSET_Y_LSB_ADDR);
-	ptr->acc_z = readRegister(BNO_ADDR, ACC_OFFSET_Z_MSB_ADDR)<<8;
-	ptr->acc_z += readRegister(BNO_ADDR, ACC_OFFSET_Z_LSB_ADDR);
-  
-	ptr->mag_x = readRegister(BNO_ADDR, MAG_OFFSET_X_MSB_ADDR)<<8;
-	ptr->mag_x += readRegister(BNO_ADDR, MAG_OFFSET_X_LSB_ADDR);
-	ptr->mag_y = readRegister(BNO_ADDR, MAG_OFFSET_Y_MSB_ADDR)<<8;
-	ptr->mag_y += readRegister(BNO_ADDR, MAG_OFFSET_Y_LSB_ADDR);
-	ptr->mag_z = readRegister(BNO_ADDR, MAG_OFFSET_Z_MSB_ADDR)<<8;
-	ptr->mag_z += readRegister(BNO_ADDR, MAG_OFFSET_Z_LSB_ADDR);
-  
-	ptr->gyr_x = readRegister(BNO_ADDR, GYR_OFFSET_X_MSB_ADDR)<<8;
-	ptr->gyr_x += readRegister(BNO_ADDR, GYR_OFFSET_X_LSB_ADDR);
-	ptr->gyr_y = readRegister(BNO_ADDR, GYR_OFFSET_Y_MSB_ADDR)<<8;
-	ptr->gyr_y += readRegister(BNO_ADDR, GYR_OFFSET_Y_LSB_ADDR);
-	ptr->gyr_z = readRegister(BNO_ADDR, GYR_OFFSET_Z_MSB_ADDR)<<8;
-	ptr->gyr_z += readRegister(BNO_ADDR, GYR_OFFSET_Z_LSB_ADDR);
+	uint8_t tmp = 0;
+	writePhase(BNO_ADDR, ACC_OFFSET_X_LSB_ADDR);
+	Wire.requestFrom(BNO_ADDR, 22, true);
+	while(Wire.available() < 22);
 
-	ptr->acc_rad = readRegister(BNO_ADDR, ACC_RADIUS_MSB_ADDR)<<8;
-	ptr->acc_rad += readRegister(BNO_ADDR, ACC_RADIUS_LSB_ADDR);
+	//ACCEL OFFSETS
+	tmp = Wire.read();
+	ptr->acc_x = Wire.read()<<8;
+	ptr->acc_x += tmp;
 
-	ptr->mag_rad = readRegister(BNO_ADDR, MAG_RADIUS_MSB_ADDR)<<8;
-	ptr->mag_rad += readRegister(BNO_ADDR, MAG_RADIUS_LSB_ADDR);
+	tmp = Wire.read();
+	ptr->acc_y = Wire.read()<<8;
+	ptr->acc_y += tmp;
+
+	tmp = Wire.read();
+	ptr->acc_z = Wire.read()<<8;
+	ptr->acc_z += tmp;
+
+	//MAG OFFSETS
+	tmp = Wire.read();
+	ptr->mag_x = Wire.read()<<8;
+	ptr->mag_x += tmp;
+
+	tmp = Wire.read();
+	ptr->mag_y = Wire.read()<<8;
+	ptr->mag_y += tmp;
+
+	tmp = Wire.read();
+	ptr->mag_z = Wire.read()<<8;
+	ptr->mag_z += tmp;
+
+	//GYRO OFFSETS
+	tmp = Wire.read();
+	ptr->gyr_x = Wire.read()<<8; 
+	ptr->gyr_x += tmp;
+                             
+	tmp = Wire.read();
+	ptr->gyr_y = Wire.read()<<8;
+	ptr->gyr_y += tmp;
+                             
+	tmp = Wire.read();
+	ptr->gyr_z = Wire.read()<<8;
+	ptr->gyr_z += tmp;
+
+	//ACCEL RADIUS
+	tmp = Wire.read();
+	ptr->acc_rad = Wire.read()<<8;
+	ptr->acc_rad += tmp;
+
+	//MAG RADIUS
+	tmp = Wire.read();
+	ptr->mag_rad = Wire.read()<<8;
+	ptr->mag_rad += tmp;
 }
 
 void BNO::setOffsets(struct calibOffsets *ptr)	//writes given offset structure into the compass

--- a/BohleBots_BNO055.cpp
+++ b/BohleBots_BNO055.cpp
@@ -106,14 +106,14 @@ void BNO::startBNO(uint8_t impact, bool forward)	//enables High_g Interrupt and 
 
 /***** Private Functions *****/
 
-void BNO::writePhase(uint8_t regaddr)	//Write Phase needed to tell from which address we want to read
+inline void BNO::writePhase(uint8_t regaddr)	//Write Phase needed to tell from which address we want to read
 {
 	Wire.beginTransmission(BNO_ADDR);
 	Wire.write(regaddr);
 	Wire.endTransmission();
 }
 
-uint8_t BNO::readRegister(uint8_t regaddr)	//reads byte from a register
+inline uint8_t BNO::readRegister(uint8_t regaddr)	//reads byte from a register
 {
 	uint8_t value = 0;
 	writePhase(regaddr);
@@ -123,7 +123,7 @@ uint8_t BNO::readRegister(uint8_t regaddr)	//reads byte from a register
 	return value;
 }
 
-uint16_t BNO::readRegister16(uint8_t regaddr)
+inline uint16_t BNO::readRegister16(uint8_t regaddr)
 {
 	uint16_t value = 0;
 	uint8_t tmp = 0;
@@ -136,7 +136,7 @@ uint16_t BNO::readRegister16(uint8_t regaddr)
 	return value;
 }
 
-void BNO::writeRegister(uint8_t regaddr, uint8_t value)	//writes byte to a register
+inline void BNO::writeRegister(uint8_t regaddr, uint8_t value)	//writes byte to a register
 {
 	Wire.beginTransmission(BNO_ADDR);
 	Wire.write(regaddr);
@@ -233,7 +233,7 @@ void BNO::setOffsets(struct calibOffsets *ptr)	//writes given offset structure i
 	writeRegister(MAG_RADIUS_LSB_ADDR, (ptr->mag_rad)&B11111111);
 
 	writeRegister(OPR_MODE_ADDR, OPR_MODE_NDOF);
-	delay(19);
+	delay(7);
 }
 
 void BNO::getCalibStat(struct calibStat *ptr)	//gets current calibration status

--- a/BohleBots_BNO055.h
+++ b/BohleBots_BNO055.h
@@ -124,10 +124,10 @@ class BNO
 			int16_t acc_rad;
 			int16_t mag_rad;
 		} _offsetData;
-		void writePhase(uint8_t addr, uint8_t regaddr);
-		uint8_t readRegister(uint8_t addr, uint8_t regaddr);
-		uint16_t readRegister16(uint8_t addr, uint8_t regaddr);
-		void writeRegister(uint8_t addr, uint8_t regaddr, uint8_t value);
+		void writePhase(uint8_t regaddr);
+		uint8_t readRegister(uint8_t regaddr);
+		uint16_t readRegister16(uint8_t regaddr);
+		void writeRegister(uint8_t regaddr, uint8_t value);
 		void setOffsets(struct calibOffsets *ptr);
 		void getOffsets(struct calibOffsets *ptr);
 		void getCalibStat(struct calibStat *ptr);

--- a/BohleBots_BNO055.h
+++ b/BohleBots_BNO055.h
@@ -126,6 +126,7 @@ class BNO
 		} _offsetData;
 		void writePhase(uint8_t addr, uint8_t regaddr);
 		uint8_t readRegister(uint8_t addr, uint8_t regaddr);
+		uint16_t readRegister16(uint8_t addr, uint8_t regaddr);
 		void writeRegister(uint8_t addr, uint8_t regaddr, uint8_t value);
 		void setOffsets(struct calibOffsets *ptr);
 		void getOffsets(struct calibOffsets *ptr);


### PR DESCRIPTION
# Improvements
## avg. execution time before patch
`getImpact()` =~ 400µs
`getHeading()` =~ 600µs
`isCalibrated()` =~ 1000µs
`saveOffsets()` =~ 4500µs
`loadOffsets()` =~ 46000µs

# Related
- #12 